### PR TITLE
Update APIGatewayV2Lambda path getter

### DIFF
--- a/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
@@ -40,6 +40,7 @@ extension APIGatewayV2Request: APIRequest {
     var path: String {
         return context.http.path
     }
+
     var httpMethod: AWSLambdaEvents.HTTPMethod { context.http.method }
     var multiValueQueryStringParameters: [String: [String]]? { nil }
     var multiValueHeaders: HTTPMultiValueHeaders { [:] }

--- a/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
@@ -38,10 +38,8 @@ extension HBLambda where Output == APIGatewayV2Response {
 // conform `APIGatewayV2Request` to `APIRequest` so we can use HBRequest.init(context:application:from)
 extension APIGatewayV2Request: APIRequest {
     var path: String {
-        // use routeKey as path has stage in it
-        return String(routeKey.split(separator: " ", maxSplits: 1).last!)
+        return context.http.path
     }
-
     var httpMethod: AWSLambdaEvents.HTTPMethod { context.http.method }
     var multiValueQueryStringParameters: [String: [String]]? { nil }
     var multiValueHeaders: HTTPMultiValueHeaders { [:] }


### PR DESCRIPTION
Use the `context.http.path` value, which is set when using catchall routes in the serverless file.


## catchall routes in the serverless file
```serverless
functions:
  http:
    handler: handle
    memorySize: 1024
    timeout: 30
    events:
        - httpApi: '*'
```

From testing it seems like the `routeKey` is only fully set if the path is defined in the serverless file, since the code isn't using the stage portion of the routeKey anyway I'd suggest using the more standard path. Worth noting that `APIGatewayRequest` is already using the path property.

In the case of catchall paths
you can see the incoming request as logged to cloudwatch here
<img width="530" alt="Screenshot 2023-06-30 at 11 37 22 PM" src="https://github.com/hummingbird-project/hummingbird-lambda/assets/15266950/51df8964-4a3d-4563-8262-71a1655dc4e8">

