### PR TITLE
HBLambda.buildResponder

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
         .package(url: "https://github.com/swift-server/swift-aws-lambda-runtime.git", from: "1.0.0-alpha"),
         .package(url: "https://github.com/swift-server/swift-aws-lambda-events.git", from: "0.1.0"),
         .package(url: "https://github.com/swift-extras/swift-extras-base64.git", from: "0.5.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", branch: "base-request-context"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", branch: "2.x.x"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.32.0"),
     ],
     targets: [

--- a/Sources/HBLambdaTest/maths.swift
+++ b/Sources/HBLambdaTest/maths.swift
@@ -17,7 +17,6 @@ import AWSLambdaRuntime
 import Hummingbird
 import HummingbirdFoundation
 import HummingbirdLambda
-import NIO
 import Logging
 
 struct DebugMiddleware: HBMiddleware {
@@ -50,12 +49,7 @@ struct MathsHandler: HBLambda {
         let result: Double
     }
 
-    let router: HBRouterBuilder<Context>
-    var responder: some HBResponder<Context> {
-        self.router.buildResponder()
-    }
-
-    init() async throws {
+    func buildResponder() -> some HBResponder<Context> {
         let router = HBRouterBuilder(context: Context.self)
         router.middlewares.add(DebugMiddleware())
         router.post("add") { request, context -> Result in
@@ -74,7 +68,7 @@ struct MathsHandler: HBLambda {
             let operands = try request.decode(as: Operands.self, using: context)
             return Result(result: operands.lhs / operands.rhs)
         }
-        self.router = router
+        return router.buildResponder()
     }
 
     func shutdown() async throws {}

--- a/Sources/HummingbirdLambda/Lambda.swift
+++ b/Sources/HummingbirdLambda/Lambda.swift
@@ -12,13 +12,13 @@
 //
 //===----------------------------------------------------------------------===//
 
+import AWSLambdaEvents
 import AWSLambdaRuntimeCore
 import Hummingbird
 import HummingbirdFoundation
 import Logging
 import NIOCore
 import NIOPosix
-import AWSLambdaEvents
 
 /// Protocol for Hummingbird Lambdas. Define the `In` and `Out` types, how you convert from `In` to `HBRequest` and `HBResponse` to `Out`
 public protocol HBLambda {
@@ -29,10 +29,11 @@ public protocol HBLambda {
     associatedtype Encoder: HBResponseEncoder = JSONEncoder
     associatedtype Decoder: HBRequestDecoder = JSONDecoder
 
-    var responder: Responder { get }
+    func buildResponder() -> Responder
+
     var encoder: Encoder { get }
     var decoder: Decoder { get }
-    var applicationContext: HBApplicationContext { get }
+    var configuration: HBApplicationConfiguration { get }
 
     /// Initialize application.
     ///
@@ -83,15 +84,8 @@ extension HBLambda {
         HBLambdaHandler<Self>.main()
     }
 
-    public var applicationContext: HBApplicationContext {
-        HBApplicationContext(
-            threadPool: NIOSingletons.posixBlockingThreadPool,
-            configuration: HBApplicationConfiguration(),
-            logger: Logger(label: "hb-lambda"),
-            encoder: encoder,
-            decoder: decoder
-        )
-    }
-
     public func shutdown() async throws {}
+
+    /// default configuration
+    public var configuration: HBApplicationConfiguration { .init() }
 }

--- a/Sources/HummingbirdLambda/LambdaHandler.swift
+++ b/Sources/HummingbirdLambda/LambdaHandler.swift
@@ -16,6 +16,7 @@ import AWSLambdaRuntime
 import Hummingbird
 import Logging
 import NIOCore
+import NIOPosix
 
 /// Specialization of EventLoopLambdaHandler which runs an HBLambda
 public struct HBLambdaHandler<L: HBLambda>: LambdaHandler {
@@ -40,8 +41,14 @@ public struct HBLambdaHandler<L: HBLambda>: LambdaHandler {
         }
 
         self.lambda = lambda
-        self.responder = lambda.responder
-        self.applicationContext = lambda.applicationContext
+        self.responder = lambda.buildResponder()
+        self.applicationContext = HBApplicationContext(
+            threadPool: NIOThreadPool.singleton,
+            configuration: lambda.configuration,
+            logger: context.logger,
+            encoder: lambda.encoder,
+            decoder: lambda.decoder
+        )
     }
 
     /// Handle invoke

--- a/Tests/HummingbirdLambdaTests/LambdaTests.swift
+++ b/Tests/HummingbirdLambdaTests/LambdaTests.swift
@@ -117,18 +117,13 @@ final class LambdaTests: XCTestCase {
 
     func testSimpleRoute() async throws {
         struct HelloLambda: HBAPIGatewayLambda {
-            let router: HBRouterBuilder<Context>
-            var responder: some HBResponder<Context> {
-                self.router.buildResponder()
-            }
-
-            init() {
+            func buildResponder() -> some HBResponder<Context> {
                 let router = HBRouterBuilder(context: Context.self)
                 router.middlewares.add(HBLogRequestsMiddleware(.debug))
                 router.get("hello") { _, _ in
                     return "Hello"
                 }
-                self.router = router
+                return router.buildResponder()
             }
         }
         let lambda = try await HBLambdaHandler<HelloLambda>(context: self.initializationContext)
@@ -142,12 +137,7 @@ final class LambdaTests: XCTestCase {
 
     func testBase64Encoding() async throws {
         struct HelloLambda: HBAPIGatewayLambda {
-            let router: HBRouterBuilder<Context>
-            var responder: some HBResponder<Context> {
-                self.router.buildResponder()
-            }
-
-            init() {
+            func buildResponder() -> some HBResponder<Context> {
                 let router = HBRouterBuilder(context: Context.self)
                 router.middlewares.add(HBLogRequestsMiddleware(.debug))
                 router.post { request, _ in
@@ -156,7 +146,7 @@ final class LambdaTests: XCTestCase {
                     }
                     return HBResponse(status: .ok, body: .init(byteBuffer: buffer))
                 }
-                self.router = router
+                return router.buildResponder()
             }
         }
         let lambda = try await HBLambdaHandler<HelloLambda>(context: self.initializationContext)
@@ -175,18 +165,13 @@ final class LambdaTests: XCTestCase {
             typealias Output = APIGatewayV2Response
             typealias Context = HBBasicLambdaRequestContext<Event>
 
-            let router: HBRouterBuilder<Context>
-            var responder: some HBResponder<Context> {
-                self.router.buildResponder()
-            }
-
-            init() {
+            func buildResponder() -> some HBResponder<Context> {
                 let router = HBRouterBuilder(context: Context.self)
                 router.middlewares.add(HBLogRequestsMiddleware(.debug))
                 router.post { _, _ in
                     return "hello"
                 }
-                self.router = router
+                return router.buildResponder()
             }
         }
         let lambda = try await HBLambdaHandler<HelloLambda>(context: self.initializationContext)
@@ -199,18 +184,13 @@ final class LambdaTests: XCTestCase {
 
     func testErrorEncoding() async throws {
         struct HelloLambda: HBAPIGatewayV2Lambda {
-            let router: HBRouterBuilder<Context>
-            var responder: some HBResponder<Context> {
-                self.router.buildResponder()
-            }
-
-            init() {
+            func buildResponder() -> some HBResponder<Context> {
                 let router = HBRouterBuilder(context: Context.self)
                 router.middlewares.add(HBLogRequestsMiddleware(.debug))
                 router.post { _, _ -> String in
                     throw HBHTTPError(.badRequest, message: "BadRequest")
                 }
-                self.router = router
+                return router.buildResponder()
             }
         }
 


### PR DESCRIPTION
Given the variable `responder` is creating the responder you should probably make this a function. Then given that logic you might as well build the router inside that function as well. I think these changes make it clearer what needs to be done. Also the test lambdas just look cleaner.

I also think we shouldn't ask the user to generate the HBApplicationContext. Some of its members should be coming from the LambdaContext and the thread pool should be set up by us. 

Thoughts?

One other thing. I didn't change but I don't think it is necessary to have a generic Encoder and Decoder. They get used as existentials internally in HB. 