### PR TITLE
Make HBLambdaHandler internal

### DIFF
--- a/Sources/HummingbirdLambda/LambdaHandler.swift
+++ b/Sources/HummingbirdLambda/LambdaHandler.swift
@@ -19,7 +19,7 @@ import NIOCore
 import NIOPosix
 
 /// Specialization of LambdaHandler which runs an HBLambda
-public struct HBLambdaHandler<L: HBLambda>: LambdaHandler {
+struct HBLambdaHandler<L: HBLambda>: LambdaHandler {
     public typealias Event = L.Event
     public typealias Output = L.Output
 

--- a/Tests/HummingbirdLambdaTests/LambdaTests.swift
+++ b/Tests/HummingbirdLambdaTests/LambdaTests.swift
@@ -14,7 +14,7 @@
 
 import AWSLambdaEvents
 @testable import AWSLambdaRuntimeCore
-import HummingbirdLambda
+@testable import HummingbirdLambda
 import Logging
 import NIOCore
 import NIOPosix


### PR DESCRIPTION
No need to have this as a public symbol as it is created by `HBLambda`.