### PR TITLE
Support launching a HBMixedLambdaApplication as either HTTP or Lambda

### DIFF
--- a/Sources/HummingbirdLambda/Lambda.swift
+++ b/Sources/HummingbirdLambda/Lambda.swift
@@ -83,7 +83,4 @@ extension HBLambda {
     }
 
     public func shutdown() async throws {}
-
-    /// default configuration
-    public var configuration: HBApplicationConfiguration { .init() }
 }

--- a/Sources/HummingbirdLambda/MixedLambdaApplication.swift
+++ b/Sources/HummingbirdLambda/MixedLambdaApplication.swift
@@ -1,0 +1,66 @@
+import Hummingbird
+import AWSLambdaRuntime
+import Logging
+import NIOCore
+import NIOPosix
+
+public enum HBBasicMixedLambdaContext<Event: Sendable>: HBLambdaRequestContext, HBRequestContext {
+    case lambda(HBBasicLambdaRequestContext<Event>)
+    case http(HBBasicRequestContext)
+
+    public var coreContext: HBCoreRequestContext {
+        get {
+            switch self {
+            case .lambda(let context):
+                return context.coreContext
+            case .http(let context):
+                return context.coreContext
+            }
+        }
+        set {
+            switch self {
+            case .lambda(var context):
+                context.coreContext = newValue
+                self = .lambda(context)
+            case .http(var context):
+                context.coreContext = newValue
+                self = .http(context)
+            }
+        }
+    }
+
+    public init(_ event: Event, lambdaContext: LambdaContext) {
+        self = .lambda(HBBasicLambdaRequestContext(event, lambdaContext: lambdaContext))
+    }
+
+    public init(allocator: ByteBufferAllocator, logger: Logger) {
+        self = .http(HBBasicRequestContext(allocator: allocator, logger: logger))
+    }
+
+    public init(channel: any Channel, logger: Logger) {
+        self = .http(HBBasicRequestContext(channel: channel, logger: logger))
+    }
+}
+
+public protocol HBMixedLambdaApplication: HBLambda, HBApplicationProtocol where Context: HBLambdaRequestContext<Event> & HBRequestContext {
+    static var hostingMode: HostingMode { get async throws }
+
+    init()
+}
+
+public enum HostingMode {
+    case lambda, server
+}
+
+extension HBMixedLambdaApplication {
+    public static func main() async throws {
+        switch try await Self.hostingMode {
+        case .lambda:
+            HBLambdaHandler<Self>.main()
+        case .server:
+            try await Self().runService()
+        }
+    }
+
+    public var responder: Responder { buildResponder() }
+}


### PR DESCRIPTION
This PR allows users to conform to `HBMixedLambdaApplication` (both `HBApplicationProtocol` and `HBLambda`). This allows running in either mode, through a getter. The example implementation toggles based on a value in the `HBEnvironment`.

Naming is very much open for discussion, I'm far from happy with this name