### PR TITLE
2.x.x: Fix multi-value query values and headers for APIGatewayV2

### DIFF
--- a/Sources/HummingbirdLambda/APIGatewayLambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayLambda.swift
@@ -57,7 +57,25 @@ extension HBLambda where Output == APIGatewayResponse {
 }
 
 // conform `APIGatewayRequest` to `APIRequest` so we can use HBRequest.init(context:application:from)
-extension APIGatewayRequest: APIRequest {}
+extension APIGatewayRequest: APIRequest {
+    var queryString: String {
+        func urlPercentEncoded(_ string: String) -> String {
+            return string.addingPercentEncoding(withAllowedCharacters: .urlQueryComponentAllowed) ?? string
+        }
+        var queryParams: [String] = []
+        var queryStringParameters = self.queryStringParameters ?? [:]
+        // go through list of multi value query string params first, removing any
+        // from the single value list if they are found in the multi value list
+        self.multiValueQueryStringParameters?.forEach { multiValueQuery in
+            queryStringParameters[multiValueQuery.key] = nil
+            queryParams += multiValueQuery.value.map { "\(urlPercentEncoded(multiValueQuery.key))=\(urlPercentEncoded($0))" }
+        }
+        queryParams += queryStringParameters.map {
+            "\(urlPercentEncoded($0.key))=\(urlPercentEncoded($0.value))"
+        }
+        return queryParams.joined(separator: "&")
+    }
+}
 
 // conform `APIGatewayResponse` to `APIResponse` so we can use HBResponse.apiReponse()
 extension APIGatewayResponse: APIResponse {}

--- a/Sources/HummingbirdLambda/APIGatewayLambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayLambda.swift
@@ -75,6 +75,20 @@ extension APIGatewayRequest: APIRequest {
         }
         return queryParams.joined(separator: "&")
     }
+
+    var httpHeaders: [(name: String, value: String)] {
+        var headerValues = [(name: String, value: String)].init()
+        var originalHeaders = self.headers
+        headerValues.reserveCapacity(headers.count)
+        for header in self.multiValueHeaders {
+            originalHeaders[header.key] = nil
+            for value in header.value {
+                headerValues.append((name: header.key, value: value))
+            }
+        }
+        headerValues.append(contentsOf: originalHeaders.map { (name: $0.key, value: $0.value) })
+        return headerValues
+    }
 }
 
 // conform `APIGatewayResponse` to `APIResponse` so we can use HBResponse.apiReponse()

--- a/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
@@ -63,9 +63,15 @@ extension APIGatewayV2Request: APIRequest {
     }
 
     var httpMethod: AWSLambdaEvents.HTTPMethod { context.http.method }
-    var multiValueQueryStringParameters: [String: [String]]? { nil }
-    var multiValueHeaders: HTTPMultiValueHeaders { [:] }
     var queryString: String { self.rawQueryString }
+    var httpHeaders: [(name: String, value: String)] {
+        self.headers.flatMap { header in
+            let headers = header.value
+                .split(separator: ",")
+                .map { (name: header.key, value: String($0.drop(while: \.isWhitespace))) }
+            return headers
+        }
+    }
 }
 
 // conform `APIGatewayV2Response` to `APIResponse` so we can use HBResponse.apiReponse()

--- a/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
@@ -65,6 +65,7 @@ extension APIGatewayV2Request: APIRequest {
     var httpMethod: AWSLambdaEvents.HTTPMethod { context.http.method }
     var multiValueQueryStringParameters: [String: [String]]? { nil }
     var multiValueHeaders: HTTPMultiValueHeaders { [:] }
+    var queryString: String { self.rawQueryString }
 }
 
 // conform `APIGatewayV2Response` to `APIResponse` so we can use HBResponse.apiReponse()

--- a/Sources/HummingbirdLambda/Request+APIGateway.swift
+++ b/Sources/HummingbirdLambda/Request+APIGateway.swift
@@ -23,8 +23,7 @@ import NIOCore
 protocol APIRequest {
     var path: String { get }
     var httpMethod: AWSLambdaEvents.HTTPMethod { get }
-    var queryStringParameters: [String: String]? { get }
-    var multiValueQueryStringParameters: [String: [String]]? { get }
+    var queryString: String { get }
     var headers: AWSLambdaEvents.HTTPHeaders { get }
     var multiValueHeaders: HTTPMultiValueHeaders { get }
     var body: String? { get }
@@ -44,19 +43,8 @@ extension HBRequest {
 
         // construct URI with query parameters
         var uri = from.path
-        var queryParams: [String] = []
-        var queryStringParameters = from.queryStringParameters ?? [:]
-        // go through list of multi value query string params first, removing any
-        // from the single value list if they are found in the multi value list
-        from.multiValueQueryStringParameters?.forEach { multiValueQuery in
-            queryStringParameters[multiValueQuery.key] = nil
-            queryParams += multiValueQuery.value.map { "\(urlPercentEncoded(multiValueQuery.key))=\(urlPercentEncoded($0))" }
-        }
-        queryParams += queryStringParameters.map {
-            "\(urlPercentEncoded($0.key))=\(urlPercentEncoded($0.value))"
-        }
-        if queryParams.count > 0 {
-            uri += "?\(queryParams.joined(separator: "&"))"
+        if from.queryString.count > 0 {
+            uri += "?\(from.queryString)"
         }
         // construct headers
         var authority: String?


### PR DESCRIPTION
Added new protocol requirements for APIRequest which return the query string and http headers in a generic form. Implement both of these for APIGatewayRequest and APIGatewayV2Request

There are no tests in this PR as the tests are in the XCTest PR #25 and adding any here will just produce merge issues