### PR TITLE
Fix APIGatewayV2 response cookie handling (multiValueHeaders → cookies)

### DIFF
--- a/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
@@ -57,7 +57,7 @@ extension APIGatewayV2Response: APIResponse {
         let setCookieHeaderName = "set-cookie"
         
         func isSetCookieHeader(_ name: String) -> Bool {
-            name.lowercased() == setCookieHeaderName
+            name.caseInsensitiveCompare(setCookieHeaderName) == .orderedSame
         }
         
         var outputHeaders = headers ?? [:]

--- a/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
@@ -54,7 +54,46 @@ extension APIGatewayV2Response: APIResponse {
         body: String?,
         isBase64Encoded: Bool?
     ) {
-        precondition(multiValueHeaders == nil || multiValueHeaders?.isEmpty == true, "Multi value headers are unavailable in APIGatewayV2")
-        self.init(statusCode: statusCode, headers: headers, body: body, isBase64Encoded: isBase64Encoded, cookies: nil)
+        let setCookieHeaderName = "set-cookie"
+        
+        func isSetCookieHeader(_ name: String) -> Bool {
+            name.lowercased() == setCookieHeaderName
+        }
+        
+        var outputHeaders = headers ?? [:]
+        var cookies: [String] = []
+        
+        // Move any single Set-Cookie header into the APIGatewayV2 cookies array.
+        var cookieKeys: [String] = []
+        for (name, value) in outputHeaders {
+            if isSetCookieHeader(name) {
+                cookies.append(value)
+                cookieKeys.append(name)
+            }
+        }
+        // Remove set-cookie from outputHeaders
+        for key in cookieKeys {
+            outputHeaders.removeValue(forKey: key)
+        }
+    
+        // Move any multi-value Set-Cookie headers into the APIGatewayV2 cookies array.
+        // For other repeated headers, fold them into a single comma-separated value.
+        if let multiValueHeaders {
+            for (name, values) in multiValueHeaders {
+                if isSetCookieHeader(name) {
+                    cookies.append(contentsOf: values)
+                } else {
+                    outputHeaders[name] = values.joined(separator: ",")
+                }
+            }
+        }
+                
+        self.init(
+            statusCode: statusCode,
+            headers: outputHeaders.isEmpty ? nil : outputHeaders,
+            body: body,
+            isBase64Encoded: isBase64Encoded,
+            cookies: cookies.isEmpty ? nil : cookies
+        )
     }
 }

--- a/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
+++ b/Sources/HummingbirdLambda/APIGatewayV2Lambda.swift
@@ -55,14 +55,14 @@ extension APIGatewayV2Response: APIResponse {
         isBase64Encoded: Bool?
     ) {
         let setCookieHeaderName = "set-cookie"
-        
+
         func isSetCookieHeader(_ name: String) -> Bool {
             name.caseInsensitiveCompare(setCookieHeaderName) == .orderedSame
         }
-        
+
         var outputHeaders = headers ?? [:]
         var cookies: [String] = []
-        
+
         // Move any single Set-Cookie header into the APIGatewayV2 cookies array.
         var cookieKeys: [String] = []
         for (name, value) in outputHeaders {
@@ -75,7 +75,7 @@ extension APIGatewayV2Response: APIResponse {
         for key in cookieKeys {
             outputHeaders.removeValue(forKey: key)
         }
-    
+
         // Move any multi-value Set-Cookie headers into the APIGatewayV2 cookies array.
         // For other repeated headers, fold them into a single comma-separated value.
         if let multiValueHeaders {
@@ -87,7 +87,7 @@ extension APIGatewayV2Response: APIResponse {
                 }
             }
         }
-                
+
         self.init(
             statusCode: statusCode,
             headers: outputHeaders.isEmpty ? nil : outputHeaders,

--- a/Sources/HummingbirdLambda/Response+APIGateway.swift
+++ b/Sources/HummingbirdLambda/Response+APIGateway.swift
@@ -33,7 +33,7 @@ extension APIResponse {
         if let trailingHeaders = collateWriter.trailingHeaders {
             headers.append(contentsOf: trailingHeaders)
         }
-        let groupedHeaders: [String: [String]] = response.headers.reduce(into: [:]) { result, item in
+        let groupedHeaders: [String: [String]] = headers.reduce(into: [:]) { result, item in
             if result[item.name.rawName] == nil {
                 result[item.name.rawName] = [item.value]
             } else {
@@ -56,7 +56,7 @@ extension APIResponse {
         }
 
         let buffer = collateWriter.buffer
-        if let contentType = response.headers[.contentType] {
+        if let contentType = headers[.contentType] {
             let mediaType = MediaType(from: contentType)
             switch mediaType {
             case .some(.text), .some(.applicationJson), .some(.applicationUrlEncoded):

--- a/Tests/HummingbirdLambdaTests/LambdaTests.swift
+++ b/Tests/HummingbirdLambdaTests/LambdaTests.swift
@@ -15,6 +15,7 @@ import NIOPosix
 import Synchronization
 import XCTest
 
+@testable import Hummingbird
 @testable import HummingbirdLambda
 
 final class LambdaTests: XCTestCase {
@@ -152,17 +153,110 @@ final class LambdaTests: XCTestCase {
     }
 
     func testHeaderValuesV2() async throws {
+        
+        struct TestCookie: Sendable {
+            let name: String
+            let value: String
+            let properties: Cookie.Properties
+
+            var expires: Date? { self.properties[.expires].flatMap { Date(httpHeader: $0) } }
+            /// indicates the maximum lifetime of the cookie in seconds. Max age has precedence over expires
+            /// (not all user agents support max-age)
+            var maxAge: Int? { self.properties[.maxAge].map { Int($0) } ?? nil }
+            /// specifies those hosts to which the cookie will be sent
+            var domain: String? { self.properties[.domain] }
+            /// The scope of each cookie is limited to a set of paths, controlled by the Path attribute
+            var path: String? { self.properties[.path] }
+            /// The Secure attribute limits the scope of the cookie to "secure" channels
+            var secure: Bool { self.properties[.secure] != nil }
+            /// The HttpOnly attribute limits the scope of the cookie to HTTP requests
+            var httpOnly: Bool { self.properties[.httpOnly] != nil }
+            /// The SameSite attribute lets servers specify whether/when cookies are sent with cross-origin requests
+            var sameSite: Cookie.SameSite? { self.properties[.sameSite].map { Cookie.SameSite(rawValue: $0) } ?? nil }
+            
+            init?(from header: String) {
+                var iterator = header.splitSequence(separator: ";").makeIterator()
+                guard let keyValue = iterator.next() else { return nil }
+                var keyValueIterator = keyValue.splitMaxSplitsSequence(separator: "=", maxSplits: 1).makeIterator()
+                guard let key = keyValueIterator.next() else { return nil }
+                guard let value = keyValueIterator.next() else { return nil }
+                self.name = String(key)
+                self.value = String(value)
+
+                var properties = Cookie.Properties()
+                // extract elements
+                while let element = iterator.next() {
+                    var keyValueIterator = element.splitMaxSplitsSequence(separator: "=", maxSplits: 1).makeIterator()
+                    guard var key = keyValueIterator.next() else { return nil }
+                    key = key.drop(while: \.isWhitespace)
+                    if let value = keyValueIterator.next() {
+                        properties[key] = String(value)
+                    } else {
+                        properties[key] = ""
+                    }
+                }
+                self.properties = properties
+            }
+
+            static func getName<S: StringProtocol>(from header: S) -> String? {
+                if let equals = header.firstIndex(of: "=") {
+                    return String(header[..<equals])
+                }
+                return nil
+            }
+            
+            func toCookie() throws -> Cookie {
+                return try Cookie.validated(name: name, value: value, expires: expires,
+                                        maxAge: maxAge, domain: domain, path: path, secure: secure, httpOnly: httpOnly, sameSite: sameSite)
+            }
+            
+        }
+        
+        struct TestCookies: Sendable {
+            
+            /// Construct cookies accessor from cookie header strings
+            /// - Parameter cookieHeaders: An array of cookie header strings
+            public init(from cookieHeaders: [String]) {
+                
+                let cookieStrings:[String:String] = cookieHeaders.reduce(into: [:])
+                { results, header in
+                    if let cookieName = TestCookie.getName(from: header) {
+                        results[cookieName] = header
+                    }
+                }
+                self.cookieStrings = cookieStrings
+            }
+
+            /// access cookies via dictionary subscript
+            public subscript(_ key: String) -> TestCookie? {
+                guard let cookieString = cookieStrings[key] else {
+                    return nil
+                }
+                return TestCookie(from: cookieString)
+            }
+
+            var cookieStrings: [String:String]
+        }
+        
+        
         let router = Router(context: BasicLambdaRequestContext<APIGatewayV2Request>.self)
         router.middlewares.add(LogRequestsMiddleware(.debug))
-        router.post { request, _ -> HTTPResponse.Status in
+        router.post { request, _ -> Response in
             XCTAssertEqual(request.headers[.userAgent], "HBXCT/2.0")
             XCTAssertEqual(request.headers[.acceptLanguage], "en")
             let cookie = request.cookies["my-cookie"]
             XCTAssertEqual(cookie?.name, "my-cookie")
             XCTAssertEqual(cookie?.value, "bar")
-            return .ok
+            
+            //Set-Cookie in response
+            let respCookie = Cookie(name: "resp-cookie", value: "xxxxxxx", maxAge: 600,
+                                    domain: "example.com", path: "/", secure: true,
+                                    httpOnly: true, sameSite: .lax)
+            var respHeaders = HTTPFields()
+            respHeaders[values: .setCookie] = [respCookie.description]
+            return Response(status: .ok, headers: respHeaders)
         }
-        router.post("/multi") { request, _ -> HTTPResponse.Status in
+        router.post("/multi") { request, _ -> Response in
             XCTAssertEqual(request.headers[.userAgent], "HBXCT/2.0")
             XCTAssertEqual(request.headers[values: .acceptLanguage], ["en", "fr"])
             // Cookies A & B are sent in the same header; cookie C is sent in a separate header
@@ -176,19 +270,90 @@ final class LambdaTests: XCTestCase {
             XCTAssertEqual(cookieC?.name, "my-cookie-c")
             XCTAssertEqual(cookieC?.value, "C")
 
-            return .ok
+            // Set Multivalue Cookies
+            var respHeaders = HTTPFields()
+            let cookieNames = ["id_token","access_token","refresh_token","auth_nonce"]
+            for cookieName in cookieNames {
+                let cookie = Cookie(name: cookieName, value: "xxxxxxx", maxAge: 600,
+                                    domain: "example.com", path: "/", secure: true,
+                                    httpOnly: true, sameSite: .lax)
+                
+                var cookies = respHeaders[values: .setCookie]
+                cookies.append(cookie.description)
+                respHeaders[values: .setCookie] = cookies
+            }
+            // Multivalue Headers
+            respHeaders[values: .accept] = ["application/json"]
+            respHeaders[values: .accept].append("text/html")
+            // Single Value Headers
+            respHeaders[.contentLanguage] = "en, de, fr"
+            return Response(status: .ok, headers: respHeaders)
         }
+        
         let lambda = APIGatewayV2LambdaFunction(router: router)
         try await lambda.test { client in
             try await client.execute(uri: "/", method: .post, headers: [.userAgent: "HBXCT/2.0", .acceptLanguage: "en", .cookie: "my-cookie=bar"]) {
                 response in
                 XCTAssertEqual(response.statusCode, .ok)
+                
+                // Cookie Validation
+                XCTAssertEqual(response.cookies?.count, 1, "Should only have 1 cookie")
+                let cookieStrings = try XCTUnwrap(response.cookies)
+                let cookie = try XCTUnwrap(Cookies(from: cookieStrings)["resp-cookie"])
+                XCTAssertEqual(cookie.name, "resp-cookie")
+                XCTAssertEqual(cookie.value, "xxxxxxx")
+                
+                // TestCookies required because Cookies fails to load anything but name and value
+                let tstCookies = TestCookies(from: cookieStrings)
+                let tstCookie = try XCTUnwrap(tstCookies["resp-cookie"]?.toCookie())
+                XCTAssertEqual(tstCookie.maxAge, 600)
+                XCTAssertEqual(tstCookie.domain, "example.com")
+                XCTAssertEqual(tstCookie.path, "/")
+                XCTAssertTrue(tstCookie.secure)
+                XCTAssertTrue(tstCookie.httpOnly)
+                XCTAssertEqual(tstCookie.sameSite, .lax)
             }
+            
             var headers: HTTPFields = [.userAgent: "HBXCT/2.0", .acceptLanguage: "en", .cookie: "my-cookie-a=A;my-cookie-b=B"]
             headers[values: .acceptLanguage].append("fr")
             headers[values: .cookie].append("my-cookie-c=C")
             try await client.execute(uri: "/multi", method: .post, headers: headers) { response in
                 XCTAssertEqual(response.statusCode, .ok)
+                
+                // Cookie Validation
+                XCTAssertEqual(response.cookies?.count, 4, "Should only have 4 cookies")
+                let cookieStrings = try XCTUnwrap(response.cookies)
+                let cookies = try XCTUnwrap(Cookies(from: cookieStrings))
+                let tstCookies = TestCookies(from: cookieStrings)
+
+                let cookieNames = ["id_token","access_token","refresh_token","auth_nonce"]
+                for cookieName in cookieNames {
+                    let cookie = try XCTUnwrap(cookies[cookieName])
+                    // TestCookies required because Cookies fails to load anything but name and value
+                    let tstCookie = try XCTUnwrap(tstCookies[cookieName]?.toCookie())
+
+                    XCTAssertEqual(cookie.name, cookieName)
+                    XCTAssertEqual(cookie.value, "xxxxxxx")
+                    XCTAssertEqual(tstCookie.maxAge, 600)
+                    XCTAssertEqual(tstCookie.domain, "example.com")
+                    XCTAssertEqual(tstCookie.path, "/")
+                    XCTAssertTrue(tstCookie.secure)
+                    XCTAssertTrue(tstCookie.httpOnly)
+                    XCTAssertEqual(tstCookie.sameSite, .lax)
+                }
+                
+                // Single Value Header Validation
+                let cLang = try XCTUnwrap(response.headers?.first(name: "Content-Language"))
+                XCTAssertEqual(cLang, "en, de, fr")
+
+                // Multivalue Header Validation
+                let acceptExpect = ["application/json","text/html"]
+                let accept = try XCTUnwrap(response.headers?.first(name: "Accept"))
+                let acceptItems = accept.split(separator: ",")
+                XCTAssertEqual(acceptItems.count, 2, "Should only have 2 Accept headers")
+                for acceptExpt in acceptExpect {
+                    XCTAssertTrue(acceptItems.contains(where: { $0 == acceptExpt }))
+                }
             }
         }
     }

--- a/Tests/HummingbirdLambdaTests/LambdaTests.swift
+++ b/Tests/HummingbirdLambdaTests/LambdaTests.swift
@@ -341,18 +341,18 @@ final class LambdaTests: XCTestCase {
                     XCTAssertTrue(tstCookie.httpOnly)
                     XCTAssertEqual(tstCookie.sameSite, .lax)
                 }
-                
+
                 // Single Value Header Validation
                 let cLang = try XCTUnwrap(response.headers?.first(name: "Content-Language"))
                 XCTAssertEqual(cLang, "en, de, fr")
 
                 // Multivalue Header Validation
-                let acceptExpect = ["application/json","text/html"]
+                let acceptExpect = ["application/json", "text/html"]
                 let accept = try XCTUnwrap(response.headers?.first(name: "Accept"))
                 let acceptItems = accept.split(separator: ",")
                 XCTAssertEqual(acceptItems.count, 2, "Should only have 2 Accept headers")
                 for acceptExpt in acceptExpect {
-                    XCTAssertTrue(acceptItems.contains(where: { $0 == acceptExpt }))
+                    XCTAssertTrue(acceptItems.contains(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines) == acceptExpt }))
                 }
             }
         }

--- a/Tests/HummingbirdLambdaTests/LambdaTests.swift
+++ b/Tests/HummingbirdLambdaTests/LambdaTests.swift
@@ -153,6 +153,48 @@ final class LambdaTests: XCTestCase {
     }
 
     func testHeaderValuesV2() async throws {
+        let router = Router(context: BasicLambdaRequestContext<APIGatewayV2Request>.self)
+        router.middlewares.add(LogRequestsMiddleware(.debug))
+        router.post { request, _ -> HTTPResponse.Status in
+            XCTAssertEqual(request.headers[.userAgent], "HBXCT/2.0")
+            XCTAssertEqual(request.headers[.acceptLanguage], "en")
+            let cookie = request.cookies["my-cookie"]
+            XCTAssertEqual(cookie?.name, "my-cookie")
+            XCTAssertEqual(cookie?.value, "bar")
+            return .ok
+        }
+        router.post("/multi") { request, _ -> HTTPResponse.Status in
+            XCTAssertEqual(request.headers[.userAgent], "HBXCT/2.0")
+            XCTAssertEqual(request.headers[values: .acceptLanguage], ["en", "fr"])
+            // Cookies A & B are sent in the same header; cookie C is sent in a separate header
+            let cookieA = request.cookies["my-cookie-a"]
+            XCTAssertEqual(cookieA?.name, "my-cookie-a")
+            XCTAssertEqual(cookieA?.value, "A")
+            let cookieB = request.cookies["my-cookie-b"]
+            XCTAssertEqual(cookieB?.name, "my-cookie-b")
+            XCTAssertEqual(cookieB?.value, "B")
+            let cookieC = request.cookies["my-cookie-c"]
+            XCTAssertEqual(cookieC?.name, "my-cookie-c")
+            XCTAssertEqual(cookieC?.value, "C")
+
+            return .ok
+        }
+        let lambda = APIGatewayV2LambdaFunction(router: router)
+        try await lambda.test { client in
+            try await client.execute(uri: "/", method: .post, headers: [.userAgent: "HBXCT/2.0", .acceptLanguage: "en", .cookie: "my-cookie=bar"]) {
+                response in
+                XCTAssertEqual(response.statusCode, .ok)
+            }
+            var headers: HTTPFields = [.userAgent: "HBXCT/2.0", .acceptLanguage: "en", .cookie: "my-cookie-a=A;my-cookie-b=B"]
+            headers[values: .acceptLanguage].append("fr")
+            headers[values: .cookie].append("my-cookie-c=C")
+            try await client.execute(uri: "/multi", method: .post, headers: headers) { response in
+                XCTAssertEqual(response.statusCode, .ok)
+            }
+        }
+    }
+
+    func testCookieReaponseV2() async throws {
         
         struct TestCookie: Sendable {
             let name: String
@@ -242,11 +284,6 @@ final class LambdaTests: XCTestCase {
         let router = Router(context: BasicLambdaRequestContext<APIGatewayV2Request>.self)
         router.middlewares.add(LogRequestsMiddleware(.debug))
         router.post { request, _ -> Response in
-            XCTAssertEqual(request.headers[.userAgent], "HBXCT/2.0")
-            XCTAssertEqual(request.headers[.acceptLanguage], "en")
-            let cookie = request.cookies["my-cookie"]
-            XCTAssertEqual(cookie?.name, "my-cookie")
-            XCTAssertEqual(cookie?.value, "bar")
             
             //Set-Cookie in response
             let respCookie = Cookie(name: "resp-cookie", value: "xxxxxxx", maxAge: 600,
@@ -257,18 +294,6 @@ final class LambdaTests: XCTestCase {
             return Response(status: .ok, headers: respHeaders)
         }
         router.post("/multi") { request, _ -> Response in
-            XCTAssertEqual(request.headers[.userAgent], "HBXCT/2.0")
-            XCTAssertEqual(request.headers[values: .acceptLanguage], ["en", "fr"])
-            // Cookies A & B are sent in the same header; cookie C is sent in a separate header
-            let cookieA = request.cookies["my-cookie-a"]
-            XCTAssertEqual(cookieA?.name, "my-cookie-a")
-            XCTAssertEqual(cookieA?.value, "A")
-            let cookieB = request.cookies["my-cookie-b"]
-            XCTAssertEqual(cookieB?.name, "my-cookie-b")
-            XCTAssertEqual(cookieB?.value, "B")
-            let cookieC = request.cookies["my-cookie-c"]
-            XCTAssertEqual(cookieC?.name, "my-cookie-c")
-            XCTAssertEqual(cookieC?.value, "C")
 
             // Set Multivalue Cookies
             var respHeaders = HTTPFields()
@@ -292,7 +317,7 @@ final class LambdaTests: XCTestCase {
         
         let lambda = APIGatewayV2LambdaFunction(router: router)
         try await lambda.test { client in
-            try await client.execute(uri: "/", method: .post, headers: [.userAgent: "HBXCT/2.0", .acceptLanguage: "en", .cookie: "my-cookie=bar"]) {
+            try await client.execute(uri: "/", method: .post) {
                 response in
                 XCTAssertEqual(response.statusCode, .ok)
                 

--- a/Tests/HummingbirdLambdaTests/LambdaTests.swift
+++ b/Tests/HummingbirdLambdaTests/LambdaTests.swift
@@ -194,7 +194,7 @@ final class LambdaTests: XCTestCase {
         }
     }
 
-    func testCookieReaponseV2() async throws {
+    func testCookieResponseV2() async throws {
         
         struct TestCookie: Sendable {
             let name: String

--- a/Tests/HummingbirdLambdaTests/LambdaTests.swift
+++ b/Tests/HummingbirdLambdaTests/LambdaTests.swift
@@ -195,7 +195,7 @@ final class LambdaTests: XCTestCase {
     }
 
     func testCookieResponseV2() async throws {
-        
+
         struct TestCookie: Sendable {
             let name: String
             let value: String
@@ -215,7 +215,7 @@ final class LambdaTests: XCTestCase {
             var httpOnly: Bool { self.properties[.httpOnly] != nil }
             /// The SameSite attribute lets servers specify whether/when cookies are sent with cross-origin requests
             var sameSite: Cookie.SameSite? { self.properties[.sameSite].map { Cookie.SameSite(rawValue: $0) } ?? nil }
-            
+
             init?(from header: String) {
                 var iterator = header.splitSequence(separator: ";").makeIterator()
                 guard let keyValue = iterator.next() else { return nil }
@@ -246,22 +246,30 @@ final class LambdaTests: XCTestCase {
                 }
                 return nil
             }
-            
+
             func toCookie() throws -> Cookie {
-                return try Cookie.validated(name: name, value: value, expires: expires,
-                                        maxAge: maxAge, domain: domain, path: path, secure: secure, httpOnly: httpOnly, sameSite: sameSite)
+                try Cookie.validated(
+                    name: name,
+                    value: value,
+                    expires: expires,
+                    maxAge: maxAge,
+                    domain: domain,
+                    path: path,
+                    secure: secure,
+                    httpOnly: httpOnly,
+                    sameSite: sameSite
+                )
             }
-            
+
         }
-        
+
         struct TestCookies: Sendable {
-            
+
             /// Construct cookies accessor from cookie header strings
             /// - Parameter cookieHeaders: An array of cookie header strings
             public init(from cookieHeaders: [String]) {
-                
-                let cookieStrings:[String:String] = cookieHeaders.reduce(into: [:])
-                { results, header in
+
+                let cookieStrings: [String: String] = cookieHeaders.reduce(into: [:]) { results, header in
                     if let cookieName = TestCookie.getName(from: header) {
                         results[cookieName] = header
                     }
@@ -277,18 +285,24 @@ final class LambdaTests: XCTestCase {
                 return TestCookie(from: cookieString)
             }
 
-            var cookieStrings: [String:String]
+            var cookieStrings: [String: String]
         }
-        
-        
+
         let router = Router(context: BasicLambdaRequestContext<APIGatewayV2Request>.self)
         router.middlewares.add(LogRequestsMiddleware(.debug))
         router.post { request, _ -> Response in
-            
+
             //Set-Cookie in response
-            let respCookie = Cookie(name: "resp-cookie", value: "xxxxxxx", maxAge: 600,
-                                    domain: "example.com", path: "/", secure: true,
-                                    httpOnly: true, sameSite: .lax)
+            let respCookie = Cookie(
+                name: "resp-cookie",
+                value: "xxxxxxx",
+                maxAge: 600,
+                domain: "example.com",
+                path: "/",
+                secure: true,
+                httpOnly: true,
+                sameSite: .lax
+            )
             var respHeaders = HTTPFields()
             respHeaders[values: .setCookie] = [respCookie.description]
             return Response(status: .ok, headers: respHeaders)
@@ -297,16 +311,24 @@ final class LambdaTests: XCTestCase {
 
             // Set Multivalue Cookies
             var respHeaders = HTTPFields()
-            let cookieNames = ["id_token","access_token","refresh_token","auth_nonce"]
+            let cookieNames = ["id_token", "access_token", "refresh_token", "auth_nonce"]
             for cookieName in cookieNames {
-                let cookie = Cookie(name: cookieName, value: "xxxxxxx", maxAge: 600,
-                                    domain: "example.com", path: "/", secure: true,
-                                    httpOnly: true, sameSite: .lax)
-                
+                let cookie = Cookie(
+                    name: cookieName,
+                    value: "xxxxxxx",
+                    maxAge: 600,
+                    domain: "example.com",
+                    path: "/",
+                    secure: true,
+                    httpOnly: true,
+                    sameSite: .lax
+                )
+
                 var cookies = respHeaders[values: .setCookie]
                 cookies.append(cookie.description)
                 respHeaders[values: .setCookie] = cookies
             }
+
             // Multivalue Headers
             respHeaders[values: .accept] = ["application/json"]
             respHeaders[values: .accept].append("text/html")
@@ -314,20 +336,20 @@ final class LambdaTests: XCTestCase {
             respHeaders[.contentLanguage] = "en, de, fr"
             return Response(status: .ok, headers: respHeaders)
         }
-        
+
         let lambda = APIGatewayV2LambdaFunction(router: router)
         try await lambda.test { client in
             try await client.execute(uri: "/", method: .post) {
                 response in
                 XCTAssertEqual(response.statusCode, .ok)
-                
+
                 // Cookie Validation
                 XCTAssertEqual(response.cookies?.count, 1, "Should only have 1 cookie")
                 let cookieStrings = try XCTUnwrap(response.cookies)
                 let cookie = try XCTUnwrap(Cookies(from: cookieStrings)["resp-cookie"])
                 XCTAssertEqual(cookie.name, "resp-cookie")
                 XCTAssertEqual(cookie.value, "xxxxxxx")
-                
+
                 // TestCookies required because Cookies fails to load anything but name and value
                 let tstCookies = TestCookies(from: cookieStrings)
                 let tstCookie = try XCTUnwrap(tstCookies["resp-cookie"]?.toCookie())
@@ -338,23 +360,24 @@ final class LambdaTests: XCTestCase {
                 XCTAssertTrue(tstCookie.httpOnly)
                 XCTAssertEqual(tstCookie.sameSite, .lax)
             }
-            
+
             var headers: HTTPFields = [.userAgent: "HBXCT/2.0", .acceptLanguage: "en", .cookie: "my-cookie-a=A;my-cookie-b=B"]
             headers[values: .acceptLanguage].append("fr")
             headers[values: .cookie].append("my-cookie-c=C")
             try await client.execute(uri: "/multi", method: .post, headers: headers) { response in
                 XCTAssertEqual(response.statusCode, .ok)
-                
+
                 // Cookie Validation
                 XCTAssertEqual(response.cookies?.count, 4, "Should only have 4 cookies")
                 let cookieStrings = try XCTUnwrap(response.cookies)
                 let cookies = try XCTUnwrap(Cookies(from: cookieStrings))
                 let tstCookies = TestCookies(from: cookieStrings)
 
-                let cookieNames = ["id_token","access_token","refresh_token","auth_nonce"]
+                let cookieNames = ["id_token", "access_token", "refresh_token", "auth_nonce"]
                 for cookieName in cookieNames {
                     let cookie = try XCTUnwrap(cookies[cookieName])
                     // TestCookies required because Cookies fails to load anything but name and value
+
                     let tstCookie = try XCTUnwrap(tstCookies[cookieName]?.toCookie())
 
                     XCTAssertEqual(cookie.name, cookieName)
@@ -368,13 +391,16 @@ final class LambdaTests: XCTestCase {
                 }
 
                 // Single Value Header Validation
+
                 let cLang = try XCTUnwrap(response.headers?.first(name: "Content-Language"))
                 XCTAssertEqual(cLang, "en, de, fr")
 
                 // Multivalue Header Validation
+
                 let acceptExpect = ["application/json", "text/html"]
                 let accept = try XCTUnwrap(response.headers?.first(name: "Accept"))
                 let acceptItems = accept.split(separator: ",")
+
                 XCTAssertEqual(acceptItems.count, 2, "Should only have 2 Accept headers")
                 for acceptExpt in acceptExpect {
                     XCTAssertTrue(acceptItems.contains(where: { $0.trimmingCharacters(in: .whitespacesAndNewlines) == acceptExpt }))


### PR DESCRIPTION
Fixes response cookie handling for APIGatewayV2Response.

While request cookies are handled correctly, response cookies are currently dropped or incorrectly serialized when using API Gateway HTTP API (payload format 2.0).

Problem

APIResponse.init() correctly groups repeated Set-Cookie headers into multiValueHeaders["set-cookie"].

However, in:
extension APIGatewayV2Response: APIResponse

the initializer:
	•	ignores multiValueHeaders
	•	sets cookies: nil
	•	enforces a precondition that multiValueHeaders must be empty

This results in:
	•	multiple cookies being lost entirely
	•	single cookies remaining in headers instead of being emitted via cookies
	
Fix
	•	Extract Set-Cookie values from:
	•	headers (single cookie case)
	•	multiValueHeaders (multiple cookie case)
	•	Move them into APIGatewayV2Response.cookies
	•	Remove Set-Cookie from standard headers
	•	Preserve other multi-value headers via comma-joining
	•	Remove incorrect precondition on multiValueHeaders

Also fixes a minor issue in APIResponse.init() where trailing headers were not included in header grouping.

Why this is correct

API Gateway HTTP API v2 requires response cookies to be returned via the top-level cookies array. Multiple Set-Cookie headers cannot be represented via standard headers or comma-joining.

https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html

⸻

Tests

Adds tests (testHeaderValuesV2) for:
	•	single Set-Cookie
	•	multiple Set-Cookie

⸻

Impact
	•	Fixes missing cookies in APIGatewayV2 responses
	•	Aligns behavior with AWS API Gateway v2 contract
	•	No impact to other Lambda integrations
